### PR TITLE
Rename `{System{Input,},Query}::access` -> `world_access`

### DIFF
--- a/src/commands/world.rs
+++ b/src/commands/world.rs
@@ -69,7 +69,10 @@ unsafe impl SystemInput for WorldQueue<'_, '_> {
         Commands::new()
     }
 
-    fn access(_state: &Self::State, builder: &mut WorldAccessBuilder<'_>) {
+    fn world_access(
+        _state: &Self::State,
+        builder: &mut WorldAccessBuilder<'_>,
+    ) {
         builder.borrows_world(Level::Read);
     }
 

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -39,7 +39,7 @@ pub struct QueryIter<'w, 's, D: QueryData> {
 ///
 /// # Safety
 ///
-/// [`QueryData::get`] must only access data set in [`QueryData::access`].
+/// [`QueryData::get`] must only access data set in [`QueryData::world_access`].
 pub unsafe trait QueryData {
     /// The type of the output data.
     type Output<'w>;
@@ -47,7 +47,7 @@ pub unsafe trait QueryData {
     /// Adds the access of this query data to the set.
     ///
     /// Used to ensure that the query accesses the world safely and correctly.
-    fn access(builder: &mut WorldAccessBuilder<'_>);
+    fn world_access(builder: &mut WorldAccessBuilder<'_>);
 
     /// Returns the query output for an entity.
     ///
@@ -55,7 +55,7 @@ pub unsafe trait QueryData {
     ///
     /// The access of this query data must have been validated. The entity
     /// pointer must be valid for the described access. All components
-    /// that are required by [`QueryData::access`] must be present in the
+    /// that are required by [`QueryData::world_access`] must be present in the
     /// entity.
     unsafe fn get(entity: EntityPtr<'_>) -> Self::Output<'_>;
 }
@@ -97,7 +97,7 @@ impl<'w, D: QueryData> Query<'w, D> {
         // SAFETY: access to world metadata is always valid
         let mut builder = WorldAccess::builder(unsafe { world.as_ref() });
 
-        D::access(&mut builder);
+        D::world_access(&mut builder);
 
         let access = builder.build();
 
@@ -247,8 +247,11 @@ unsafe impl<D: QueryData> SystemInput for Query<'_, D> {
 
     fn init(_world: &World) -> Self::State {}
 
-    fn access(_state: &Self::State, builder: &mut WorldAccessBuilder<'_>) {
-        D::access(builder);
+    fn world_access(
+        _state: &Self::State,
+        builder: &mut WorldAccessBuilder<'_>,
+    ) {
+        D::world_access(builder);
     }
 
     unsafe fn get<'w, 's>(
@@ -327,7 +330,7 @@ impl<'w, 's, D: QueryData> ExactSizeIterator for QueryIter<'w, 's, D> {}
 unsafe impl<C: Component> QueryData for &C {
     type Output<'w> = &'w C;
 
-    fn access(builder: &mut WorldAccessBuilder<'_>) {
+    fn world_access(builder: &mut WorldAccessBuilder<'_>) {
         builder.borrows_component::<C>(Level::Read);
     }
 
@@ -349,7 +352,7 @@ unsafe impl<C: Component> ReadOnlyQueryData for &C {}
 unsafe impl<C: Component> QueryData for &mut C {
     type Output<'w> = &'w mut C;
 
-    fn access(builder: &mut WorldAccessBuilder<'_>) {
+    fn world_access(builder: &mut WorldAccessBuilder<'_>) {
         builder.borrows_component::<C>(Level::Write);
     }
 
@@ -366,7 +369,7 @@ unsafe impl<C: Component> QueryData for &mut C {
 unsafe impl<C: Component> QueryData for Option<&C> {
     type Output<'w> = Option<&'w C>;
 
-    fn access(builder: &mut WorldAccessBuilder<'_>) {
+    fn world_access(builder: &mut WorldAccessBuilder<'_>) {
         builder.maybe_borrows_component::<C>(Level::Read);
     }
 
@@ -386,7 +389,7 @@ unsafe impl<C: Component> ReadOnlyQueryData for Option<&C> {}
 unsafe impl<C: Component> QueryData for Option<&mut C> {
     type Output<'w> = Option<&'w mut C>;
 
-    fn access(builder: &mut WorldAccessBuilder<'_>) {
+    fn world_access(builder: &mut WorldAccessBuilder<'_>) {
         builder.maybe_borrows_component::<C>(Level::Write);
     }
 
@@ -401,7 +404,7 @@ unsafe impl<C: Component> QueryData for Option<&mut C> {
 unsafe impl QueryData for EntityId {
     type Output<'w> = Self;
 
-    fn access(_builder: &mut WorldAccessBuilder<'_>) {}
+    fn world_access(_builder: &mut WorldAccessBuilder<'_>) {}
 
     unsafe fn get(entity: EntityPtr<'_>) -> Self::Output<'_> {
         entity.id()
@@ -419,7 +422,7 @@ unsafe impl ReadOnlyQueryData for EntityId {}
 unsafe impl QueryData for EntityRef<'_> {
     type Output<'w> = EntityRef<'w>;
 
-    fn access(builder: &mut WorldAccessBuilder<'_>) {
+    fn world_access(builder: &mut WorldAccessBuilder<'_>) {
         builder.borrows_all_entities(Level::Read);
     }
 
@@ -439,7 +442,7 @@ unsafe impl ReadOnlyQueryData for EntityRef<'_> {}
 unsafe impl QueryData for EntityMut<'_> {
     type Output<'w> = EntityMut<'w>;
 
-    fn access(builder: &mut WorldAccessBuilder<'_>) {
+    fn world_access(builder: &mut WorldAccessBuilder<'_>) {
         builder.borrows_all_entities(Level::Read);
     }
 

--- a/src/query/tuple_impl.rs
+++ b/src/query/tuple_impl.rs
@@ -8,8 +8,8 @@ macro_rules! impl_query_data {
             type Output<'w> = ($($t::Output<'w>,)*);
 
             #[allow(unused)]
-            fn access(builder: &mut crate::access::WorldAccessBuilder<'_>) {
-                $( $t::access(builder) );*
+            fn world_access(builder: &mut crate::access::WorldAccessBuilder<'_>) {
+                $( $t::world_access(builder) );*
             }
 
             #[allow(unused)]

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -11,7 +11,8 @@ mod var;
 ///
 /// # Safety
 ///
-/// [`System::run`] must only access what it declares in [`System::access`].
+/// [`System::run`] must only access what it declares in
+/// [`System::world_access`].
 pub unsafe trait System<I: SystemInput, O = ()> {
     /// The state of this system, retained between runs.
     ///
@@ -22,7 +23,7 @@ pub unsafe trait System<I: SystemInput, O = ()> {
     fn init(&mut self, world: &World) -> Self::State;
 
     /// Adds the access of this system to the set.
-    fn access(
+    fn world_access(
         &mut self,
         state: &Self::State,
         builder: &mut WorldAccessBuilder<'_>,
@@ -53,8 +54,8 @@ pub unsafe trait System<I: SystemInput, O = ()> {
 ///
 /// # Safety
 ///
-/// The access of this system set by [`SystemInput::access`] must be the same
-/// every time and must always match how the world is accessed in
+/// The access of this system set by [`SystemInput::world_access`] must be the
+/// same every time and must always match how the world is accessed in
 /// [`SystemInput::get`].
 pub unsafe trait SystemInput {
     /// This system input borrowed for a lifetime.
@@ -66,7 +67,7 @@ pub unsafe trait SystemInput {
     fn init(world: &World) -> Self::State;
 
     /// Adds the access of this system input to the set.
-    fn access(state: &Self::State, builder: &mut WorldAccessBuilder<'_>);
+    fn world_access(state: &Self::State, builder: &mut WorldAccessBuilder<'_>);
 
     /// Produces this system input from the world and state.
     ///

--- a/src/system/tuple_impl.rs
+++ b/src/system/tuple_impl.rs
@@ -19,12 +19,12 @@ macro_rules! impl_tuples {
                 <($($t,)*) as crate::system::SystemInput>::init(world)
             }
 
-            fn access(
+            fn world_access(
                 &mut self,
                 state: &Self::State,
                 builder: &mut crate::access::WorldAccessBuilder<'_>,
             ) {
-                <($($t,)*) as crate::system::SystemInput>::access(state, builder);
+                <($($t,)*) as crate::system::SystemInput>::world_access(state, builder);
             }
 
             #[allow(unused_variables)]
@@ -77,7 +77,7 @@ macro_rules! impl_tuples {
                 ($($t::init(world),)*)
             }
 
-            fn access(
+            fn world_access(
                 state: &Self::State,
                 #[allow(unused)]
                 builder: &mut crate::access::WorldAccessBuilder<'_>,
@@ -85,7 +85,7 @@ macro_rules! impl_tuples {
                 #[allow(non_snake_case)]
                 let ($($t,)*) = state;
 
-                $($t::access($t, builder));*
+                $($t::world_access($t, builder));*
             }
 
             #[allow(unused_variables, clippy::unused_unit)]

--- a/src/system/var.rs
+++ b/src/system/var.rs
@@ -35,7 +35,11 @@ unsafe impl<T: Send + Sync + 'static> SystemInput for Var<'_, T> {
         None
     }
 
-    fn access(_state: &Self::State, _builder: &mut WorldAccessBuilder<'_>) {}
+    fn world_access(
+        _state: &Self::State,
+        _builder: &mut WorldAccessBuilder<'_>,
+    ) {
+    }
 
     unsafe fn get<'w, 's>(
         state: &'s mut Self::State,


### PR DESCRIPTION
Personally I think it makes the methods slightly more readable.