### PR TITLE
Make system input/output assosciated types

### DIFF
--- a/src/resource/mod.rs
+++ b/src/resource/mod.rs
@@ -223,7 +223,7 @@ impl<R: Resource> DerefMut for ResMut<'_, R> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::system::System;
+    use crate::prelude::*;
 
     #[derive(Resource)]
     struct Counter(usize);
@@ -239,22 +239,24 @@ mod tests {
         let mut world = World::new();
 
         {
-            let mut state = non_requiring_system.init(&world);
+            let mut system = non_requiring_system.into_system();
+            let mut state = system.init(&world);
 
             // SAFETY: The system is read-only and world pointer is valid as it
             // was constructed from a reference.
-            unsafe { non_requiring_system.run(&mut state, world.as_ptr()) };
+            unsafe { system.run(&mut state, world.as_ptr()) };
         }
 
         world.create(Counter(0));
 
         {
-            let mut state = requiring_system.init(&world);
+            let mut system = requiring_system.into_system();
+            let mut state = system.init(&world);
 
             // SAFETY: The world pointer is valid as it was constructed from a
             // mutable reference. The required accesses (only `Counter`)
             // exists in the world
-            unsafe { requiring_system.run(&mut state, world.as_ptr_mut()) };
+            unsafe { system.run(&mut state, world.as_ptr_mut()) };
         }
 
         let counter: Res<'_, Counter> = world.resource().unwrap();

--- a/src/system/function.rs
+++ b/src/system/function.rs
@@ -1,0 +1,33 @@
+use std::marker::PhantomData;
+
+use super::{IntoSystem, System, SystemInput};
+
+/// A type that wraps functions to implement [`System`].
+pub struct FunctionSystem<I, O, F>
+where
+    I: SystemInput,
+{
+    pub(super) function: F,
+    pub(super) _marker: PhantomData<fn(I) -> O>,
+}
+
+impl<I: SystemInput, O, F> FunctionSystem<I, O, F> {
+    /// Creates a new function system.
+    pub fn new(function: F) -> Self {
+        Self { function, _marker: PhantomData }
+    }
+}
+
+// impls of `System` are in `tuple_impl.rs`
+
+impl<I, O, F> IntoSystem<I, O> for FunctionSystem<I, O, F>
+where
+    Self: System<Input = I, Output = O>,
+    I: SystemInput,
+{
+    type Output = Self;
+
+    fn into_system(self) -> Self::Output {
+        self
+    }
+}

--- a/src/system/var.rs
+++ b/src/system/var.rs
@@ -52,7 +52,7 @@ unsafe impl<T: Send + Sync + 'static> SystemInput for Var<'_, T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::system::System;
+    use crate::system::{IntoSystem, System};
 
     #[test]
     fn var_is_retained() {
@@ -63,6 +63,7 @@ mod tests {
         }
 
         let world = World::new();
+        let mut system = system.into_system();
         let mut state = system.init(&world);
 
         // SAFETY: the system access is valid as it doesn't access anything, the


### PR DESCRIPTION
Makes it easier to do blanket impls on systems. Also allows for stateful systems in the future.