### PR TITLE
Remove `System::State`

### DIFF
--- a/src/resource/mod.rs
+++ b/src/resource/mod.rs
@@ -240,23 +240,26 @@ mod tests {
 
         {
             let mut system = non_requiring_system.into_system();
-            let mut state = system.init(&world);
 
-            // SAFETY: The system is read-only and world pointer is valid as it
-            // was constructed from a reference.
-            unsafe { system.run(&mut state, world.as_ptr()) };
+            system.init(&world);
+
+            // SAFETY: The system initialized and is read-only and world pointer
+            // is valid as it was constructed from a reference.
+            unsafe { system.run(world.as_ptr()) };
         }
 
         world.create(Counter(0));
 
         {
             let mut system = requiring_system.into_system();
-            let mut state = system.init(&world);
 
-            // SAFETY: The world pointer is valid as it was constructed from a
-            // mutable reference. The required accesses (only `Counter`)
-            // exists in the world
-            unsafe { system.run(&mut state, world.as_ptr_mut()) };
+            system.init(&world);
+
+            // SAFETY: The system is initialized and the world pointer is valid
+            // as it was constructed from a mutable reference. The
+            // required accesses (only `Counter`) exists in the
+            // world
+            unsafe { system.run(world.as_ptr_mut()) };
         }
 
         let counter: Res<'_, Counter> = world.resource().unwrap();

--- a/src/system/function.rs
+++ b/src/system/function.rs
@@ -8,13 +8,26 @@ where
     I: SystemInput,
 {
     pub(super) function: F,
-    pub(super) _marker: PhantomData<fn(I) -> O>,
+    pub(super) state: Option<I::State>,
+    pub(super) _output: PhantomData<fn() -> O>,
 }
 
 impl<I: SystemInput, O, F> FunctionSystem<I, O, F> {
     /// Creates a new function system.
     pub fn new(function: F) -> Self {
-        Self { function, _marker: PhantomData }
+        let state = None;
+
+        Self { function, state, _output: PhantomData }
+    }
+
+    /// Returns a reference to the state of this system.
+    pub fn state(&self) -> Option<&I::State> {
+        self.state.as_ref()
+    }
+
+    /// Returns a mutable reference to the state of this system.
+    pub fn state_mut(&mut self) -> Option<&mut I::State> {
+        self.state.as_mut()
     }
 }
 

--- a/src/system/var.rs
+++ b/src/system/var.rs
@@ -64,12 +64,14 @@ mod tests {
 
         let world = World::new();
         let mut system = system.into_system();
-        let mut state = system.init(&world);
 
-        // SAFETY: the system access is valid as it doesn't access anything, the
-        // world pointer is valid
-        unsafe { system.run(&mut state, world.as_ptr()) };
+        system.init(&world);
+        // SAFETY: The system is initialized, system access is valid as it
+        // doesn't access anything, the world pointer is valid
+        unsafe { system.run(world.as_ptr()) };
 
-        assert_eq!(state.0, Some(1));
+        let (var,) = system.state().unwrap();
+
+        assert_eq!(var.as_ref(), Some(&1));
     }
 }


### PR DESCRIPTION
Also fixes tuples of `SystemInput`s not passing through `SystemInput::{needs_}sync` impls.