### PR TITLE
Refactor `World::spawn_iter` signature and `tuple_impl`'s, satisfy `clippy`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ name = "worldlines"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 version.workspace = true
 
 [lib]
@@ -31,6 +32,7 @@ members = ["macros"]
 authors = ["Alexandra Reaves <nyxalexandra@proton.me>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/NyxAlexandra/worldlines"
 version = "0.1.0"
 
 # benchmarks

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -4,6 +4,7 @@ name = "worldlines-macros"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 version.workspace = true
 
 [lib]

--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -17,8 +17,6 @@ mod set;
 mod storage;
 mod tuple_impl;
 
-// TODO: docs for deriving hooks
-
 /// Trait for components, the data stored in an entity.
 ///
 /// # Deriving

--- a/src/component/tuple_impl.rs
+++ b/src/component/tuple_impl.rs
@@ -1,35 +1,35 @@
-macro_rules! impl_bundle {
-    ($($t:ident),*) => {
-        impl_bundle!([] [$($t)*]);
+macro_rules! tuple_impl {
+    ($($c:ident),*) => {
+        tuple_impl!([] [$($c)*]);
     };
 
-    ([$($t:ident)*] []) => {
-        unsafe impl<$($t),*> crate::component::Bundle for ($($t,)*)
+    ([$($c:ident)*] []) => {
+        unsafe impl<$($c),*> crate::component::Bundle for ($($c,)*)
         where
-            $($t: crate::component::Bundle),*
+            $($c: crate::component::Bundle),*
         {
             #[allow(unused, non_snake_case)]
             fn components(builder: &mut crate::component::ComponentSetBuilder<'_>) {
-                $($t::components(builder));*
+                $($c::components(builder));*
             }
 
             #[allow(unused, non_snake_case)]
             fn write(self, writer: &mut crate::component::ComponentWriter<'_, '_>) {
-                let ($($t,)*) = self;
+                let ($($c,)*) = self;
 
                 $(
-                    $t.write(writer);
+                    $c.write(writer);
                 )*
             }
         }
     };
 
-    ([$($rest:ident)*]  [$head:ident $($tail:ident)*]) => {
-        impl_bundle!([$($rest)*] []);
-        impl_bundle!([$($rest)* $head] [$($tail)*]);
+    ([$($rest:ident)*]  [$head:ident $($cail:ident)*]) => {
+        tuple_impl!([$($rest)*] []);
+        tuple_impl!([$($rest)* $head] [$($cail)*]);
     };
 }
 
-impl_bundle!(
+tuple_impl!(
     C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, C12, C13, C14, C15
 );

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -287,7 +287,7 @@ impl<'w, 's, D: QueryData> IntoIterator for &'s mut Query<'w, D> {
     }
 }
 
-impl<'w, 's, D: QueryData> Iterator for QueryIter<'w, 's, D> {
+impl<'w, D: QueryData> Iterator for QueryIter<'w, '_, D> {
     type Item = D::Output<'w>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -322,7 +322,7 @@ impl<'w, 's, D: QueryData> Iterator for QueryIter<'w, 's, D> {
     }
 }
 
-impl<'w, 's, D: QueryData> ExactSizeIterator for QueryIter<'w, 's, D> {}
+impl<D: QueryData> ExactSizeIterator for QueryIter<'_, '_, D> {}
 
 /// # Safety
 ///

--- a/src/query/tuple_impl.rs
+++ b/src/query/tuple_impl.rs
@@ -1,35 +1,35 @@
-macro_rules! impl_query_data {
-    ($($t:ident),*) => {
-        impl_query_data!([] [$($t)*]);
+macro_rules! tuple_impl {
+    ($($d:ident),*) => {
+        tuple_impl!([] [$($d)*]);
     };
 
-    ([$($t:ident)*] []) => {
-        unsafe impl<$($t: crate::query::QueryData),*> crate::query::QueryData for ($($t,)*) {
-            type Output<'w> = ($($t::Output<'w>,)*);
+    ([$($d:ident)*] []) => {
+        unsafe impl<$($d: crate::query::QueryData),*> crate::query::QueryData for ($($d,)*) {
+            type Output<'w> = ($($d::Output<'w>,)*);
 
             #[allow(unused)]
             fn world_access(builder: &mut crate::access::WorldAccessBuilder<'_>) {
-                $( $t::world_access(builder) );*
+                $( $d::world_access(builder) );*
             }
 
             #[allow(unused)]
             unsafe fn get(entity: crate::entity::EntityPtr<'_>) -> Self::Output<'_> {
                 #[allow(clippy::unused_unit)]
-                ($(unsafe { $t::get(entity) },)*)
+                ($(unsafe { $d::get(entity) },)*)
             }
         }
 
-        unsafe impl<$($t),*> crate::query::ReadOnlyQueryData for ($($t,)*)
+        unsafe impl<$($d),*> crate::query::ReadOnlyQueryData for ($($d,)*)
         where
-            $($t: crate::query::ReadOnlyQueryData,)*
+            $($d: crate::query::ReadOnlyQueryData,)*
         {
         }
     };
 
-    ([$($rest:ident)*]  [$head:ident $($tail:ident)*]) => {
-        impl_query_data!([$($rest)*] []);
-        impl_query_data!([$($rest)* $head] [$($tail)*]);
+    ([$($rest:ident)*]  [$head:ident $($dail:ident)*]) => {
+        tuple_impl!([$($rest)*] []);
+        tuple_impl!([$($rest)* $head] [$($dail)*]);
     };
 }
 
-impl_query_data!(D0, D1, D2, D3, D4, D5, D6, D7);
+tuple_impl!(D0, D1, D2, D3, D4, D5, D6, D7);

--- a/src/world/ptr.rs
+++ b/src/world/ptr.rs
@@ -48,7 +48,7 @@ impl<'w> WorldPtr<'w> {
     }
 }
 
-impl<'w> fmt::Debug for WorldPtr<'w> {
+impl fmt::Debug for WorldPtr<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.world.fmt(f)
     }


### PR DESCRIPTION
`World::spawn_iter` no longer takes a `B: Bundle`, instead placing the
requirement on the iterator (`impl IntoIterator<Item: Bundle>`).

All tuple-implementing macros are renamed to `tuple_impl` and now take
arguments that match the letter passed in (for example,`C0, C1, .., Cn`
-> `$c`).

`clippy`'s complaints about unneeded explicit lifetimes are solved.
